### PR TITLE
Add PIM linker plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-  
+
 # Logs
 logs
 *.log
@@ -50,4 +50,5 @@ package-lock.json
 
 # dotenv environment variables file
 .env
-.env.test
+.env.development
+.env.production

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Now you can do the following things:
 
 ## Nacelle Base Schema
 
-By cloning this Content Studio Starter we've already got all of the schemas needed to setup content on your Nacelle build.
+By cloning this Content Studio Starter we've already got all of the schemas needed to set up content on your Nacelle build.
 
 ### Local development
 
@@ -19,7 +19,15 @@ By cloning this Content Studio Starter we've already got all of the schemas need
 
 2. **Initialize project by running `sanity init` in the root folder.**
     - This will log you in to Sanity, create a project, set up a dataset, and generate the files needed to run the editing environment locally.
-    
+
 3. **Install dependencies with `npm install` in the root folder.**
 
 4. **Start the development server by running `sanity start` or `npm run start` in root folder**
+
+### Nacelle PIM Linker Plugin
+
+This studio starter includes [@nacelle/sanity-plugin-pim-linker](https://www.npmjs.com/package/@nacelle/sanity-plugin-pim-linker). This plugin provides a custom input component that makes it easier to reference product & collection data stored in Nacelle indices.
+
+Check out [./schemas/productGrid.js](https://github.com/getnacelle/nacelle-sanity-content-studio/blob/master/schemas/productGrid.js) to see some of the possibilities.
+
+Be sure to add your Nacelle spaceID and token in **./config/@nacelle/sanity-plugin-pim-linker.json**

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ This studio starter includes [@nacelle/sanity-plugin-pim-linker](https://www.npm
 
 Check out [./schemas/productGrid.js](https://github.com/getnacelle/nacelle-sanity-content-studio/blob/master/schemas/productGrid.js) to see some of the possibilities.
 
-Be sure to add your Nacelle spaceID and token in **./config/@nacelle/sanity-plugin-pim-linker.json**
+Be sure to add your Nacelle spaceID and token in **./config/@nacelle/sanity-plugin-pim-linker.json**. Or you can remove that file and instead set spaceId and token in `.env.development` / .`env.production`.

--- a/config/.checksums
+++ b/config/.checksums
@@ -3,5 +3,6 @@
   "@sanity/default-layout": "bb034f391ba508a6ca8cd971967cbedeb131c4d19b17b28a0895f32db5d568ea",
   "@sanity/default-login": "6fb6d3800aa71346e1b84d95bbcaa287879456f2922372bb0294e30b968cd37f",
   "@sanity/form-builder": "b38478227ba5e22c91981da4b53436df22e48ff25238a55a973ed620be5068aa",
-  "@sanity/data-aspects": "d199e2c199b3e26cd28b68dc84d7fc01c9186bf5089580f2e2446994d36b3cb6"
+  "@sanity/data-aspects": "d199e2c199b3e26cd28b68dc84d7fc01c9186bf5089580f2e2446994d36b3cb6",
+  "@nacelle/sanity-plugin-pim-linker": "728e18b6c78c47c8e814c03e7c9c13fe5ec012020a4ba69ab6bc47fe2b072b13"
 }

--- a/config/@nacelle/sanity-plugin-pim-linker.json
+++ b/config/@nacelle/sanity-plugin-pim-linker.json
@@ -1,0 +1,4 @@
+{
+  "nacelleSpaceId": "your-nacelle-space-id",
+  "nacelleSpaceToken": "your-nacelle-graphql-token"
+}

--- a/package.json
+++ b/package.json
@@ -16,16 +16,19 @@
     "sanity"
   ],
   "dependencies": {
+    "@nacelle/sanity-plugin-pim-linker": "^0.0.3",
     "@sanity/base": "^1.149.10",
     "@sanity/components": "^1.149.10",
     "@sanity/core": "^1.149.12",
     "@sanity/default-layout": "^1.149.10",
     "@sanity/default-login": "^1.149.11",
     "@sanity/desk-tool": "^1.149.10",
+    "@sanity/ui": "^0.33.7",
     "@sanity/vision": "^1.149.0",
     "prop-types": "^15.6",
     "react": "^16.2",
-    "react-dom": "^16.2"
+    "react-dom": "^16.2",
+    "styled-components": "^5.2.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.11.0",

--- a/sanity.json
+++ b/sanity.json
@@ -12,13 +12,12 @@
     "@sanity/components",
     "@sanity/default-layout",
     "@sanity/default-login",
-    "@sanity/desk-tool"
+    "@sanity/desk-tool",
+    "@nacelle/sanity-plugin-pim-linker"
   ],
   "env": {
     "development": {
-      "plugins": [
-        "@sanity/vision"
-      ]
+      "plugins": ["@sanity/vision"]
     }
   },
   "parts": [

--- a/schemas/productGrid.js
+++ b/schemas/productGrid.js
@@ -46,7 +46,35 @@ export default {
       name: 'blogHandle',
       title: 'Blog Handle',
       type: 'string',
-    }
+    },
+    {
+      name: 'pimHandle',
+      title: 'Collection or Product',
+      type: 'nacelleData',
+    },
+    {
+      name: 'collectionHandle',
+      title: 'Collection',
+      type: 'nacelleData',
+      options: {
+        dataType: ['collections'],
+      },
+    },
+    {
+      name: 'productHandles',
+      title: 'Multiple Products',
+      type: 'array',
+      of: [
+        {
+          name: 'productHandle',
+          title: 'Product',
+          type: 'nacelleData',
+          options: {
+            dataType: ['products'],
+          },
+        },
+      ],
+    },
   ],
 
   preview: {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [[DRAMS-539](https://nacelle.atlassian.net/browse/DRAMS-539)]

### WHAT is this pull request doing?

- adds @nacelle/sanity-plugin-pim-linker plugin
- updates productGrid schema with examples using the PIM linker component (`type: 'nacelleData'`)
