### PR TITLE
Add spaces option to connect to 'sales-demo' dataset

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "start": "sanity start",
-    "check": "sanity check",
+    "deploy": "sanity deploy",
     "lint": "eslint ./",
     "test": "jest"
   },

--- a/sanity.json
+++ b/sanity.json
@@ -7,6 +7,25 @@
     "projectId": "ciu31kkt",
     "dataset": "production"
   },
+  "__experimental_spaces": [
+    {
+      "name": "production",
+      "title": "Prod",
+      "default": true,
+      "api": {
+        "projectId": "ciu31kkt",
+        "dataset": "production"
+      }
+    },
+    {
+      "name": "sales-demo",
+      "title": "Sales Demo",
+      "api": {
+        "projectId": "ciu31kkt",
+        "dataset": "sales-demo"
+      }
+    }
+  ],
   "plugins": [
     "@sanity/base",
     "@sanity/components",


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses [[DRAMS-1393](https://nacelle.atlassian.net/browse/DRAMS-1393)]
 
### WHAT is this pull request doing?

Enable dataset switching with the `__experimental_spaces` option in sanity.json 