### PR TITLE
Add preview plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ By cloning this Content Studio Starter we've already got all of the schemas need
 3. **Install dependencies with `npm install` in the root folder.**
 
 4. **Start the development server by running `sanity start` or `npm run start` in root folder**
-
+ 
 ### Nacelle PIM Linker Plugin
 
 This studio starter includes [@nacelle/sanity-plugin-pim-linker](https://www.npmjs.com/package/@nacelle/sanity-plugin-pim-linker). This plugin provides a custom input component that makes it easier to reference product & collection data stored in Nacelle indices.
@@ -31,3 +31,23 @@ This studio starter includes [@nacelle/sanity-plugin-pim-linker](https://www.npm
 Check out [./schemas/productGrid.js](https://github.com/getnacelle/nacelle-sanity-content-studio/blob/master/schemas/productGrid.js) to see some of the possibilities.
 
 Be sure to add your Nacelle spaceID and token in **./config/@nacelle/sanity-plugin-pim-linker.json**. Or you can remove that file and instead set spaceId and token in `.env.development` / .`env.production`.
+
+### Preview Plugin
+
+This studio starter also includes the [@sanity/production-preview](https://www.sanity.io/docs/preview-content-on-site). With this plugin you can preview unpublished drafts of your page entries on your site.
+
+Include your preview URL in a .env file. This is the default base route for your site's pages.
+
+With our Nuxt starter this would be:
+
+```sh
+PREVIEW_URL="https://myshop-preview.foo.app/{entry_field.handle}"
+```
+
+With our Next.js starter this would be:
+
+```sh
+PREVIEW_URL="https://myshop.foo.app/api/preview?path=/pages/"
+```
+
+Now with the studio running locally or deployed you should see an 'Open preview' menu item appear in the document's context menu. Click that and you'll see you're draft content just like were live!

--- a/README.md
+++ b/README.md
@@ -41,13 +41,15 @@ Include your preview URL in a .env file. This is the default base route for your
 With our Nuxt starter this would be:
 
 ```sh
-PREVIEW_URL="https://myshop-preview.foo.app/{entry_field.handle}"
+PREVIEW_URL="https://myshop-preview.foo.app/"
 ```
 
 With our Next.js starter this would be:
 
 ```sh
-PREVIEW_URL="https://myshop.foo.app/api/preview?path=/pages/"
+PREVIEW_URL="https://myshop-preview.foo.app/api/preview?path=/"
 ```
 
-Now with the studio running locally or deployed you should see an 'Open preview' menu item appear in the document's context menu. Click that and you'll see you're draft content just like were live!
+In `./resolveProductionUrl.js` you can customize how you would like previewing to work for different page routes or content types.
+
+Now with the studio running locally or deployed you will see an 'Open preview' menu item appear in the document's context menu. Click that and you'll see you're draft content just like it were live!

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@sanity/default-layout": "^2.5.0",
     "@sanity/default-login": "^2.2.6",
     "@sanity/desk-tool": "^2.5.0",
+    "@sanity/production-preview": "^2.2.6",
     "@sanity/ui": "^0.33.7",
     "@sanity/vision": "^2.2.6",
     "prop-types": "^15.6",

--- a/resolveProductionUrl.js
+++ b/resolveProductionUrl.js
@@ -1,0 +1,6 @@
+// Refer to Sanity's docs on using the preview plugin
+// https://www.sanity.io/docs/preview-content-on-site
+
+export default function resolveProductionUrl(document) {
+  return `https://nacelle-nextjs-sanity-demo.vercel.app/api/preview?path=/pages/${document.handle.current}`
+}

--- a/resolveProductionUrl.js
+++ b/resolveProductionUrl.js
@@ -2,5 +2,17 @@
 // https://www.sanity.io/docs/preview-content-on-site
 
 export default function resolveProductionUrl(document) {
-  return `${process.env.PREVIEW_URL}${document.handle.current}`
+  const previewUrl = process.env.SANITY_STUDIO_PREVIEW_URL
+  const handle = document && document.handle && document.handle.current
+  const type = document && document._type
+
+  if (type === 'page') {
+    // limit previewing to pages
+
+    if (handle === 'homepage') {
+      return previewUrl
+    } else if (handle) {
+      return `${previewUrl}pages/${handle}`
+    }
+  }
 }

--- a/resolveProductionUrl.js
+++ b/resolveProductionUrl.js
@@ -2,5 +2,5 @@
 // https://www.sanity.io/docs/preview-content-on-site
 
 export default function resolveProductionUrl(document) {
-  return `https://nacelle-nextjs-sanity-demo.vercel.app/api/preview?path=/pages/${document.handle.current}`
+  return `${process.env.PREVIEW_URL}${document.handle.current}`
 }

--- a/sanity.json
+++ b/sanity.json
@@ -32,7 +32,8 @@
     "@sanity/default-layout",
     "@sanity/default-login",
     "@sanity/desk-tool",
-    "@nacelle/sanity-plugin-pim-linker"
+    "@nacelle/sanity-plugin-pim-linker",
+    "@sanity/production-preview"
   ],
   "env": {
     "development": {
@@ -43,6 +44,10 @@
     {
       "name": "part:@sanity/base/schema",
       "path": "./schemas/schema"
+    },
+    {
+      "implements": "part:@sanity/production-preview/resolve-production-url",
+      "path": "./resolveProductionUrl.js"
     }
   ]
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses [[DRAMS-1396](https://nacelle.atlassian.net/browse/DRAMS-1396)]


### WHAT is this pull request doing?

- adds the `@sanity/production-preview` plugin
- plugin is configured in `resolveProductionUrl.js` with env var
- Readme updated to explain how to use the plugin

### How to Test

Use `sanity-plugin-pim-linker.json` with:

```json
{
  "nacelleSpaceId": "your-nacelle-space-id",
  "nacelleSpaceToken": "your-nacelle-graphql-token"
}
```

Add preview url to .env

```env
PREVIEW_URL="https://nacelle-nextjs-sanity-demo.vercel.app/api/preview?path=/pages/"
```