### PR TITLE
[Husky] Add npx prefix to pre-commit command

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged",
+      "pre-commit": "npx lint-staged",
       "pre-push": "npm run test"
     }
   }


### PR DESCRIPTION
When making commits on a Windows machine, using `npx lint-staged` instead of `lint-staged` fixes an error with path references.

> Error: Cannot find module 'C:\lint-staged\bin\lint-staged.js' 

Solution found here: https://stackoverflow.com/questions/61196309/husky-4-x-not-working-with-visual-studio-git