### PR TITLE
Remove __experimental_spaces property from config

### DIFF
--- a/sanity.json
+++ b/sanity.json
@@ -7,25 +7,6 @@
     "projectId": "ciu31kkt",
     "dataset": "production"
   },
-  "__experimental_spaces": [
-    {
-      "name": "production",
-      "title": "Prod",
-      "default": true,
-      "api": {
-        "projectId": "ciu31kkt",
-        "dataset": "production"
-      }
-    },
-    {
-      "name": "sales-demo",
-      "title": "Sales Demo",
-      "api": {
-        "projectId": "ciu31kkt",
-        "dataset": "sales-demo"
-      }
-    }
-  ],
   "plugins": [
     "@sanity/base",
     "@sanity/components",


### PR DESCRIPTION
### WHY are these changes introduced?

The `__experimental_spaces` property of the sanity.json config contains hard-coded references to an internal Nacelle Sanity project ID. This property would not be overridden when setting up Sanity Studio, causing confusion among merchants and internal stakeholders alike resulting from trying to access a Sanity project to which they did not have access.

### WHAT is this pull request doing?

This pull request removes the `__experimental_spaces` property from configuration so that the Sanity Studio directs users to the project ID populated when the project is first set up, rather than to an internal Nacelle project.